### PR TITLE
fix radii not parsed on Android

### DIFF
--- a/android/src/main/kotlin/devflowstud/io/device_corner_radius/DeviceCornerRadiusPlugin.kt
+++ b/android/src/main/kotlin/devflowstud/io/device_corner_radius/DeviceCornerRadiusPlugin.kt
@@ -51,23 +51,33 @@ class DeviceCornerRadiusPlugin: FlutterPlugin, MethodCallHandler, ActivityAware 
 
   private fun getCornerRadius(view: View): Map<String, Any> {
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-      val insets = view.rootWindowInsets
-      val topLeft = insets?.getRoundedCorner(RoundedCorner.POSITION_TOP_LEFT)?.radius ?: 0f
-      val topRight = insets?.getRoundedCorner(RoundedCorner.POSITION_TOP_RIGHT)?.radius ?: 0f
-      val bottomLeft = insets?.getRoundedCorner(RoundedCorner.POSITION_BOTTOM_LEFT)?.radius ?: 0f
-      val bottomRight = insets?.getRoundedCorner(RoundedCorner.POSITION_BOTTOM_RIGHT)?.radius ?: 0f
-      mapOf(
-        "topLeft" to topLeft,
-        "topRight" to topRight,
-        "bottomLeft" to bottomLeft,
-        "bottomRight" to bottomRight
-      )
+      val density = this.activity.resources.displayMetrics.density.toDouble()
+      if (density == 0.0) {
+        mapOf(
+          "topLeft" to 0.0,
+          "topRight" to 0.0,
+          "bottomLeft" to 0.0,
+          "bottomRight" to 0.0
+        )
+      } else {
+        val insets = view.rootWindowInsets
+        val topLeft = (insets?.getRoundedCorner(RoundedCorner.POSITION_TOP_LEFT)?.radius ?: 0f).toDouble()
+        val topRight = (insets?.getRoundedCorner(RoundedCorner.POSITION_TOP_RIGHT)?.radius ?: 0f).toDouble()
+        val bottomLeft = (insets?.getRoundedCorner(RoundedCorner.POSITION_BOTTOM_LEFT)?.radius ?: 0f).toDouble()
+        val bottomRight = (insets?.getRoundedCorner(RoundedCorner.POSITION_BOTTOM_RIGHT)?.radius ?: 0f).toDouble()
+        mapOf(
+          "topLeft" to topLeft / density,
+          "topRight" to topRight / density,
+          "bottomLeft" to bottomLeft / density,
+          "bottomRight" to bottomRight / density
+        )
+      }
     } else {
       mapOf(
-        "topLeft" to 0,
-        "topRight" to 0,
-        "bottomLeft" to 0,
-        "bottomRight" to 0
+        "topLeft" to 0.0,
+        "topRight" to 0.0,
+        "bottomLeft" to 0.0,
+        "bottomRight" to 0.0
       )
     }
   }

--- a/lib/device_corner_radius_method_channel.dart
+++ b/lib/device_corner_radius_method_channel.dart
@@ -15,14 +15,27 @@ class MethodChannelDeviceCornerRadius extends DeviceCornerRadiusPlatform {
     try {
       radii as Map;
       return BorderRadius.only(
-        topLeft: Radius.circular(radii['topLeft'] as double),
-        topRight: Radius.circular(radii['topRight'] as double),
-        bottomLeft: Radius.circular(radii['bottomLeft'] as double),
-        bottomRight: Radius.circular(radii['bottomRight'] as double),
+        topLeft: Radius.circular(_asDouble(radii['topLeft'])),
+        topRight: Radius.circular(_asDouble(radii['topRight'])),
+        bottomLeft: Radius.circular(_asDouble(radii['bottomLeft'])),
+        bottomRight: Radius.circular(_asDouble(radii['bottomRight'])),
       );
     } catch (e) {
       throw Exception('Failed to parse radii ');
     }
   }
-  
+}
+
+double _asDouble(dynamic value) {
+  if (value is double) {
+    return value;
+  } else if (value is int) {
+    return value.toDouble();
+  } else if (value is num) {
+    return value.toDouble();
+  } else if (value is String) {
+    return double.parse(value.trim());
+  } else {
+    throw FormatException("value $value could not be mapped to double");
+  }
 }


### PR DESCRIPTION
On Android I'm getting `int` returned by the platform, added more paranoid double parsing function to cope with this.

Additionally the returned corners where not factoring in the device density,

closes #1 